### PR TITLE
using python -m

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,10 @@ pip install physical-ai-interpretability
 Easiest way to use the attention mapper is to run a post-hoc attention analysis of an existing dataset. In this case, we run our pre-trained policy on episodes in the dataset and capture the attention maps. This requires no connection to any robots and should work out of the box.
 
 ```
-python examples/visualise_original_data_attention.py --dataset-repo-id lerobot/svla_so101_pickplace --episode-id 29 --policy-path <path to your pre-trained policy> --output-dir ./output/attention_analysis_results
+python -m examples.visualise_original_data_attention --dataset-repo-id lerobot/svla_so101_pickplace --episode-id 29 --policy-path <path to your pre-trained policy> --output-dir ./output/attention_analysis_results
 ```
 
 Pre-trained policy part may look something like this: `../lerobot/outputs/train/act_johns_arm/checkpoints/last/pretrained_model`
-
-If you get an error with `ModuleNotFoundError: No module named 'src'`, set the `PYTHONPATH` environment variable to the location of `physical-ai-interpretability` in your local directory, e.g.  
-`PYTHONPATH=/home/ville/physical-ai-interpretability:$PYTHONPATH`.
 
 ### Use at test-time
 


### PR DESCRIPTION
Made a small change. Using `python -m examples.visualise_original_data_attention` to avoid the `ModuleNotFoundError: No module named 'src'` issue. 

This works because `python -m` runs from the repo root, so `src/` is included in Python’s import search path. With the old method (`python examples/...`), Python only added the `examples/` folder to the search path, so it couldn’t see `src/` and the import fails.